### PR TITLE
Import local tspan package explicitly

### DIFF
--- a/latest/wavedrompy/waveform.py
+++ b/latest/wavedrompy/waveform.py
@@ -13,7 +13,7 @@ from itertools import chain
 
 import svgwrite
 from six import string_types
-from wavedrom.tspan import JsonMLElement
+from .tspan import JsonMLElement
 
 from . import waveskin
 from .attrdict import AttrDict


### PR DESCRIPTION
otherwise I get an error because it will look for a wavedrom package in the PYTHON PATH.

Tested with inkscape 1.4 on Linux.